### PR TITLE
Prometheus and normalization filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,21 +98,21 @@ statsd-http-proxy --version
 
 Command line arguments:
 
-| Parameter       | Description                          | Default value                                                                     |
-|-----------------|--------------------------------------|-----------------------------------------------------------------------------------|
-| verbose         | Print debug info to stderr           | Optional. Default false                                                           |
-| http-host       | Host of HTTP server                  | Optional. Default 127.0.0.1. To accept connections on any interface, set to ""    |
-| http-port       | Port of HTTP server                  | Optional. Default 80                                                              |
-| http-timeout-read | The maximum duration in seconds for reading the entire request, including the body | Optional. Defaults to 1 second |
-| http-timeout-write | The maximum duration in seconds before timing out writes of the respons | Optional. Defaults to 1 second  |
-| http-timeout-idle | The maximum amount of time in seconds to wait for the next request when keep-alives are enabled | Optional. Defaults to 1 second |
-| tls-cert        | TLS certificate for the HTTPS        | Optional. Default "" to use HTTP. If both tls-cert and tls-key set, HTTPS is used |
-| tls-key         | TLS private key for the HTTPS        | Optional. Default "" to use HTTP. If both tls-cert and tls-key set, HTTPS is used |
-| statsd-host     | Host of StatsD instance              | Optional. Default 127.0.0.1                                                       |
-| statsd-port     | Port of StatsD instance              | Optional. Default 8125                                                            |
-| jwt-secret      | JWT token secret                     | Optional. If not set, server accepts all connections                              |
-| metric-prefix   | Prefix, added to any metric name     | Optional. If not set, do not add prefix                                           |
-| version         | Print version of server and exit     | Optional                                                                          |
+| Parameter       | Description                          | Default value                                                                                |
+|-----------------|--------------------------------------|----------------------------------------------------------------------------------------------|
+| verbose         | Print debug info to stderr           | Optional. Default false                                                                      |
+| http-host       | Host of HTTP server                  | Optional. Default 127.0.0.1. To accept connections on any interface, set to ""               |
+| http-port       | Port of HTTP server                  | Optional. Default 8825                                                                       |
+| http-timeout-read | The maximum duration in seconds for reading the entire request, including the body | Optional. Defaults to 2 seconds              |
+| http-timeout-write | The maximum duration in seconds before timing out writes of the respons | Optional. Defaults to 2 seconds                        |
+| http-timeout-idle | The maximum amount of time in seconds to wait for the next request when keep-alives are enabled | Optional. Defaults to 5 seconds |
+| tls-cert        | TLS certificate for the HTTPS        | Optional. Default "" to use HTTP. If both tls-cert and tls-key set, HTTPS is used            |
+| tls-key         | TLS private key for the HTTPS        | Optional. Default "" to use HTTP. If both tls-cert and tls-key set, HTTPS is used            |
+| statsd-host     | Host of StatsD instance              | Optional. Default 127.0.0.1                                                                  |
+| statsd-port     | Port of StatsD instance              | Optional. Default 8125                                                                       |
+| jwt-secret      | JWT token secret                     | Optional. If not set, server accepts all connections                                         |
+| metric-prefix   | Prefix, added to any metric name     | Optional. If not set, do not add prefix                                                      |
+| version         | Print version of server and exit     | Optional                                                                                     |
 
 ## Client Interactions
 

--- a/main.go
+++ b/main.go
@@ -62,6 +62,8 @@ func main() {
 	var metricPrefix = flag.String("metric-prefix", "", "Prefix of metric name")
 	var tokenSecret = flag.String("jwt-secret", "", "Secret to encrypt JWT")
 	var verbose = flag.Bool("verbose", false, "Verbose")
+	var promFilter = flag.Bool("prometheus-compat", false, "Enforce prometheus data model compatibility on incoming metrics")
+	var normalize = flag.Bool("normalize", false, "Ensure all metrics (and tags) are lower case strings")
 	var version = flag.Bool("version", false, "Show version")
 	var profilerHTTPort = flag.Int("profiler-http-port", 0, "Start profiler localhost")
 
@@ -107,6 +109,8 @@ func main() {
 		*tlsCert,
 		*tlsKey,
 		*metricPrefix,
+		*promFilter,
+		*normalize,
 		*tokenSecret,
 		*verbose,
 	)

--- a/proxy/routehandler/routehandler.go
+++ b/proxy/routehandler/routehandler.go
@@ -5,11 +5,19 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/civic-eagle/statsd-http-proxy/proxy/statsdclient"
 	log "github.com/sirupsen/logrus"
 	vmmetrics "github.com/VictoriaMetrics/metrics"
+)
+
+var (
+	allowedNames     = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_:]*$")
+	allowedFirstChar = regexp.MustCompile("^[a-zA-Z]")
+	replaceChars     = regexp.MustCompile("[^a-zA-Z0-9_:]")
+	allowedTagKeys   = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_]*$")
 )
 
 // 5 MB
@@ -19,6 +27,8 @@ const maxBodySize = 5000 * 1024 * 1024
 type RouteHandler struct {
 	statsdClient statsdclient.StatsdClientInterface
 	metricPrefix string
+	promFilter bool
+	normalize bool
 }
 
 // MetricRequest: internal representation of a metric to be written
@@ -33,11 +43,15 @@ type MetricRequest struct {
 func NewRouteHandler(
 	statsdClient statsdclient.StatsdClientInterface,
 	metricPrefix string,
+	promFilter bool,
+	normalize bool,
 ) *RouteHandler {
 	// build route handler
 	routeHandler := RouteHandler{
 		statsdClient,
 		metricPrefix,
+		promFilter,
+		normalize,
 	}
 
 	return &routeHandler
@@ -48,7 +62,7 @@ func (routeHandler *RouteHandler) HandleMetric(
 	r *http.Request,
 	metricType string,
 ) {
-	req, err := procBody(w, r)
+	req, err := procBody(w, r, routeHandler.metricPrefix, routeHandler.promFilter, routeHandler.normalize)
 	if err != nil {
 		return
 	}
@@ -71,7 +85,7 @@ func (routeHandler *RouteHandler) HandleMetricName(
 	metricType string,
 	metricName string,
 ) {
-	req, err := procBody(w, r)
+	req, err := procBody(w, r, routeHandler.metricPrefix, routeHandler.promFilter, routeHandler.normalize)
 	if err != nil {
 		return
 	}
@@ -116,7 +130,7 @@ func sendMetric(routeHandler *RouteHandler, metricType string, key string, value
 	}
 }
 
-func procBody(w http.ResponseWriter, r *http.Request) (MetricRequest, error) {
+func procBody(w http.ResponseWriter, r *http.Request, prefix string, promFilter bool, normalize bool) (MetricRequest, error) {
 	/*
 	All incoming POST requests to '/:type'
 	and '/:type/:metric' should have consistent
@@ -140,7 +154,20 @@ func procBody(w http.ResponseWriter, r *http.Request) (MetricRequest, error) {
 		return MetricRequest{}, err
 	}
 
-	return req, nil
+	if prefix != "" {
+		req.Metric = prefix + req.Metric
+	}
+
+	if normalize {
+		req.Metric = strings.ToLower(req.Metric)
+		req.Tags = strings.ToLower(req.Tags)
+	}
+
+	if promFilter {
+		return filterMetric(req)
+	} else {
+		return req, nil
+	}
 }
 
 func processTags(tagsList string) string {
@@ -163,15 +190,59 @@ func processTags(tagsList string) string {
 	for _, pair := range list {
 		pairItems := strings.Split(pair, "=")
 		if len(pairItems) != 2 {
+			vmmetrics.GetOrCreateCounter("metrics_tags_dropped_total").Inc()
 			log.WithFields(log.Fields{"Tags": tagsList, "pair": pairItems}).Debug("Missing pair")
 			return ""
 		} else if len(strings.TrimSpace(pairItems[0])) == 0 {
+			vmmetrics.GetOrCreateCounter("metrics_tags_dropped_total").Inc()
 			log.WithFields(log.Fields{"Tags": tagsList, "pair": pairItems}).Debug("Invalid tag key")
 			return ""
 		} else if len(strings.TrimSpace(pairItems[1])) == 0 {
+			vmmetrics.GetOrCreateCounter("metrics_tags_dropped_total").Inc()
 			log.WithFields(log.Fields{"Tags": tagsList, "pair": pairItems}).Debug("Invalid tag value")
 			return ""
 		}
 	}
 	return "," + tagsList
+}
+
+func filterMetric(m MetricRequest) (MetricRequest, error) {
+	metric := MetricRequest{
+		Metric: "", Value: 0, Tags: "", SampleRate: 0,
+	}
+	if !allowedFirstChar.MatchString(m.Metric) {
+		vmmetrics.GetOrCreateCounter("metrics_dropped_total").Inc()
+		return MetricRequest{}, fmt.Errorf("Invalid first character in metric name")
+	}
+	if !allowedNames.MatchString(m.Metric) {
+		metric.Metric = replaceChars.ReplaceAllString(m.Metric, "_")
+	} else {
+		metric.Metric = m.Metric
+	}
+	if m.Tags != "" {
+		list := strings.Split(strings.TrimSpace(m.Tags), ",")
+		if len(list) > 0 {
+			finalTags := ""
+			for _, pair := range list {
+				tagPair := strings.Split(pair, "=")
+				// filter out any bad tag pairs first
+				if len(tagPair) != 2 || len(strings.TrimSpace(tagPair[0])) == 0 || len(strings.TrimSpace(tagPair[1])) == 0 {
+					continue
+				}
+				if !allowedTagKeys.MatchString(tagPair[0]) {
+					tagKey := replaceChars.ReplaceAllString(tagPair[0], "_")
+					finalTags += fmt.Sprintf("%s=%s", tagKey, tagPair[1])
+				} else {
+					finalTags += pair
+				}
+			}
+			metric.Tags = finalTags
+		}
+	} else {
+		metric.Tags = ""
+	}
+	metric.Value = m.Value
+	metric.SampleRate = m.SampleRate
+
+	return metric, nil
 }

--- a/proxy/routehandler/routehandler.go
+++ b/proxy/routehandler/routehandler.go
@@ -89,7 +89,12 @@ func (routeHandler *RouteHandler) HandleMetricName(
 	if err != nil {
 		return
 	}
-	var key = metricName
+	var key string
+	if routeHandler.metricPrefix != "" {
+		key = routeHanderl.metricPrefix + metricName
+	} else {
+		key = metricName
+	}
 	if req.Tags != "" {
 		key += processTags(req.Tags)
 	}

--- a/proxy/routehandler/routehandler.go
+++ b/proxy/routehandler/routehandler.go
@@ -234,6 +234,7 @@ func filterMetric(m MetricRequest) (MetricRequest, error) {
 				tagPair := strings.Split(pair, "=")
 				// filter out any bad tag pairs first
 				if len(tagPair) != 2 || len(strings.TrimSpace(tagPair[0])) == 0 || len(strings.TrimSpace(tagPair[1])) == 0 {
+					log.WithFields(log.Fields{"Tags": list, "pair": tagPair}).Debug("Invalid tag set")
 					continue
 				}
 				if !allowedTagKeys.MatchString(tagPair[0]) {
@@ -250,6 +251,6 @@ func filterMetric(m MetricRequest) (MetricRequest, error) {
 	}
 	metric.Value = m.Value
 	metric.SampleRate = m.SampleRate
-
+	log.WithFields(log.Fields{"metric": metric}).Debug("Final Metric")
 	return metric, nil
 }

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -44,6 +45,9 @@ func NewServer(
 	// prepare metric prefix
 	if metricPrefix != "" && (metricPrefix)[len(metricPrefix)-1:] != "_" {
 		metricPrefix = metricPrefix + "_"
+	}
+	if normalize {
+		metricPrefix = strings.ToLower(metricPrefix)
 	}
 
 	// create StatsD Client

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -36,6 +36,8 @@ func NewServer(
 	tlsCert string,
 	tlsKey string,
 	metricPrefix string,
+	promFilter bool,
+	normalize bool,
 	tokenSecret string,
 	verbose bool,
 ) *Server {
@@ -51,6 +53,8 @@ func NewServer(
 	routeHandler := routehandler.NewRouteHandler(
 		statsdClient,
 		metricPrefix,
+		promFilter,
+		normalize,
 	)
 
 	// build router


### PR DESCRIPTION
start adding prometheus data model restrictions on metric names and also allow for stat normalization

Signed-off-by: John Seekins <john@civiceagle.com>